### PR TITLE
Agregar control para un segundo LED desde la web

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -24,7 +24,7 @@ void handleLedOff() {
   digitalWrite(ledPin, LOW);
   server.send(200, "text/html", "<h1>LED APAGADO</h1><a href='/'>Volver</a>");
 }
-//estoy ensayando 
+//estoy ensayando  otro ensayo 
 
 void setup() {
   Serial.begin(115200);


### PR DESCRIPTION
Agregar control para un segundo LED desde la web

Descripción:
Este Pull Request añade la funcionalidad para controlar un segundo LED conectado al pin 4 del ESP32 desde la interfaz web.

Se agregan botones para encender y apagar ambos LEDs.
Se definen nuevas rutas en el servidor web para el segundo LED.
El código es fácilmente extensible para más salidas.